### PR TITLE
feat: replace raw DOM events with TinyKeys library

### DIFF
--- a/__mocks__/tinykeys.ts
+++ b/__mocks__/tinykeys.ts
@@ -1,0 +1,63 @@
+// Mock implementation of TinyKeys for testing
+
+export type TinyKeysHandler = (event: KeyboardEvent) => void;
+export type TinyKeysBindings = Record<string, TinyKeysHandler>;
+export type TinyKeysUnsubscribe = () => void;
+
+// Mock function to track registered bindings and simulate keyboard events
+let mockBindings: TinyKeysBindings = {};
+let mockUnsubscribeFn: jest.Mock;
+
+// Mock implementation of tinykeys function
+const tinykeys = jest.fn(
+  (target: Element | Document | Window, bindings: TinyKeysBindings): TinyKeysUnsubscribe => {
+    // Store bindings for test access
+    mockBindings = { ...bindings };
+    
+    // Return mock unsubscribe function
+    mockUnsubscribeFn = jest.fn(() => {
+      mockBindings = {};
+    });
+    
+    return mockUnsubscribeFn;
+  }
+);
+
+// Helper functions for tests to access and control the mock
+export const __mockTinyKeys = {
+  // Get currently registered bindings
+  getBindings: (): TinyKeysBindings => mockBindings,
+  
+  // Simulate a keyboard event by calling the appropriate handler
+  simulateKeyEvent: (keyPattern: string, eventInit: KeyboardEventInit = {}): void => {
+    const handler = mockBindings[keyPattern];
+    if (handler) {
+      // Create a mock KeyboardEvent with the provided properties
+      const event = new KeyboardEvent(eventInit.type || 'keydown', {
+        code: eventInit.code,
+        key: eventInit.key,
+        repeat: eventInit.repeat || false,
+        ...eventInit
+      });
+      
+      // Add preventDefault method
+      Object.defineProperty(event, 'preventDefault', {
+        value: jest.fn(),
+        writable: true
+      });
+      
+      handler(event);
+    }
+  },
+  
+  // Get the unsubscribe function for testing cleanup
+  getUnsubscribe: (): jest.Mock => mockUnsubscribeFn,
+  
+  // Clear all mock data
+  clear: (): void => {
+    mockBindings = {};
+    mockUnsubscribeFn = jest.fn();
+  }
+};
+
+export default tinykeys;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "robot3": "^1.1.1"
+    "robot3": "^1.1.1",
+    "tinykeys": "^1.4.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/tests/unit/keyboard.test.ts
+++ b/tests/unit/keyboard.test.ts
@@ -7,36 +7,22 @@ import {
 } from "../../src/input/keyboard";
 import { StateMachineInputHandler } from "../../src/input/StateMachineInputHandler";
 import { Action, GameState } from "../../src/state/types";
+import { __mockTinyKeys } from "../../__mocks__/tinykeys";
 
-// Mock DOM APIs
-const mockAddEventListener = jest.fn<
-  void,
-  [string, EventListenerOrEventListenerObject]
->();
-const mockRemoveEventListener = jest.fn<
-  void,
-  [string, EventListenerOrEventListenerObject]
->();
+// Mock localStorage
 const mockLocalStorage = {
   getItem: jest.fn<string | null, [string]>(),
   setItem: jest.fn<void, [string, string]>(),
   clear: jest.fn<void, []>(),
 };
 
-Object.defineProperty(document, "addEventListener", {
-  writable: true,
-  value: mockAddEventListener,
-});
-
-Object.defineProperty(document, "removeEventListener", {
-  writable: true,
-  value: mockRemoveEventListener,
-});
-
 Object.defineProperty(window, "localStorage", {
   value: mockLocalStorage,
   writable: true,
 });
+
+// Mock TinyKeys (automatically used via Jest's __mocks__ directory)
+jest.mock("tinykeys");
 
 describe("StateMachineInputHandler", () => {
   let handler: StateMachineInputHandler;
@@ -46,10 +32,9 @@ describe("StateMachineInputHandler", () => {
     handler = new StateMachineInputHandler();
     mockDispatch = jest.fn<void, [Action]>();
 
-    mockAddEventListener.mockClear();
-    mockRemoveEventListener.mockClear();
     mockLocalStorage.getItem.mockClear();
     mockLocalStorage.setItem.mockClear();
+    __mockTinyKeys.clear();
 
     handler.init(mockDispatch);
   });
@@ -63,29 +48,27 @@ describe("StateMachineInputHandler", () => {
       expect(handler).toBeDefined();
     });
 
-    it("should bind event listeners on start", () => {
+    it("should register TinyKeys bindings on start", () => {
       handler.start();
-      expect(mockAddEventListener).toHaveBeenCalledWith(
-        "keydown",
-        expect.any(Function),
-      );
-      expect(mockAddEventListener).toHaveBeenCalledWith(
-        "keyup",
-        expect.any(Function),
-      );
+      const bindings = __mockTinyKeys.getBindings();
+      
+      // Should have keydown and keyup bindings for each key
+      expect(bindings).toHaveProperty("ArrowLeft");
+      expect(bindings).toHaveProperty("ArrowLeft|keyup");
+      expect(bindings).toHaveProperty("ArrowRight");
+      expect(bindings).toHaveProperty("ArrowRight|keyup");
+      expect(bindings).toHaveProperty("Space");
     });
 
-    it("should unbind event listeners on stop", () => {
+    it("should unsubscribe TinyKeys bindings on stop", () => {
       handler.start();
+      const unsubscribe = __mockTinyKeys.getUnsubscribe();
+      
       handler.stop();
-      expect(mockRemoveEventListener).toHaveBeenCalledWith(
-        "keydown",
-        expect.any(Function),
-      );
-      expect(mockRemoveEventListener).toHaveBeenCalledWith(
-        "keyup",
-        expect.any(Function),
-      );
+      
+      expect(unsubscribe).toHaveBeenCalled();
+      const bindingsAfterStop = __mockTinyKeys.getBindings();
+      expect(Object.keys(bindingsAfterStop)).toHaveLength(0);
     });
   });
 
@@ -132,39 +115,21 @@ describe("StateMachineInputHandler", () => {
     it("should dispatch input event on left key down and up (complete tap)", () => {
       handler.start();
 
-      // Find keydown handler
-      const keyDownCall = mockAddEventListener.mock.calls.find(
-        (call) => call[0] === "keydown",
-      );
-      if (!keyDownCall || typeof keyDownCall[1] !== "function") {
-        throw new Error("keydown handler not found");
-      }
-      const keyDownHandler = keyDownCall[1];
-
-      // Find keyup handler
-      const keyUpCall = mockAddEventListener.mock.calls.find(
-        (call) => call[0] === "keyup",
-      );
-      if (!keyUpCall || typeof keyUpCall[1] !== "function") {
-        throw new Error("keyup handler not found");
-      }
-      const keyUpHandler = keyUpCall[1];
-
       // Simulate key down (should not dispatch yet)
-      const keyDownEvent = new KeyboardEvent("keydown", {
+      __mockTinyKeys.simulateKeyEvent("ArrowLeft", {
+        type: "keydown",
         code: "ArrowLeft",
         repeat: false,
       });
-      keyDownHandler(keyDownEvent);
 
       // No dispatch on keydown
       expect(mockDispatch).not.toHaveBeenCalled();
 
       // Simulate key up (should dispatch TapMove)
-      const keyUpEvent = new KeyboardEvent("keyup", {
+      __mockTinyKeys.simulateKeyEvent("ArrowLeft|keyup", {
+        type: "keyup",
         code: "ArrowLeft",
       });
-      keyUpHandler(keyUpEvent);
 
       // Should dispatch TapMove for completed tap
       expect(mockDispatch).toHaveBeenCalledWith({
@@ -177,19 +142,10 @@ describe("StateMachineInputHandler", () => {
     it("should dispatch input event on key up", () => {
       handler.start();
 
-      const keyEvent = new KeyboardEvent("keyup", {
+      __mockTinyKeys.simulateKeyEvent("ArrowLeft|keyup", {
+        type: "keyup",
         code: "ArrowLeft",
       });
-
-      const keyUpCall = mockAddEventListener.mock.calls.find(
-        (call) => call[0] === "keyup",
-      );
-      if (!keyUpCall || typeof keyUpCall[1] !== "function") {
-        throw new Error("keyup handler not found");
-      }
-      const keyUpHandler = keyUpCall[1];
-
-      keyUpHandler(keyEvent);
 
       // Key up events don't dispatch actions in the new DAS system
       expect(mockDispatch).not.toHaveBeenCalled();
@@ -198,20 +154,11 @@ describe("StateMachineInputHandler", () => {
     it("should ignore key repeat events", () => {
       handler.start();
 
-      const keyEvent = new KeyboardEvent("keydown", {
+      __mockTinyKeys.simulateKeyEvent("ArrowLeft", {
+        type: "keydown",
         code: "ArrowLeft",
         repeat: true,
       });
-
-      const keyDownCall = mockAddEventListener.mock.calls.find(
-        (call) => call[0] === "keydown",
-      );
-      if (!keyDownCall || typeof keyDownCall[1] !== "function") {
-        throw new Error("keydown handler not found");
-      }
-      const keyDownHandler = keyDownCall[1];
-
-      keyDownHandler(keyEvent);
 
       expect(mockDispatch).not.toHaveBeenCalled();
     });
@@ -220,20 +167,11 @@ describe("StateMachineInputHandler", () => {
       document.body.classList.add("settings-open");
       handler.start();
 
-      const keyEvent = new KeyboardEvent("keydown", {
+      __mockTinyKeys.simulateKeyEvent("ArrowLeft", {
+        type: "keydown",
         code: "ArrowLeft",
         repeat: false,
       });
-
-      const keyDownCall = mockAddEventListener.mock.calls.find(
-        (call) => call[0] === "keydown",
-      );
-      if (!keyDownCall || typeof keyDownCall[1] !== "function") {
-        throw new Error("keydown handler not found");
-      }
-      const keyDownHandler = keyDownCall[1];
-
-      keyDownHandler(keyEvent);
 
       expect(mockDispatch).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Replaces raw DOM event listeners with TinyKeys library for simplified keyboard input handling.

## Changes
- Add tinykeys dependency to package.json
- Refactor StateMachineInputHandler to use TinyKeys instead of raw DOM events
- Create buildTinyKeysBindings() method to convert KeyBindings format
- Consolidate key event handling into handleKeyEvent() method
- Update setKeyBindings() to rebuild TinyKeys bindings when changed
- Add Jest mock for TinyKeys library to enable testing
- Update keyboard tests to use TinyKeys mock instead of DOM mocks

This simplifies the input handling code while maintaining all existing functionality including touch input compatibility, settings keybinding display, and DAS/ARR timing.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)