### PR TITLE
Restore ghost piece visibility and structure after overlay refactor

### DIFF
--- a/src/engine/selectors/overlays.ts
+++ b/src/engine/selectors/overlays.ts
@@ -68,7 +68,7 @@ export function selectGhostOverlay(s: GameState): GhostOverlay | null {
     cells: ghostCells,
     id: `ghost:${ghostPosition.id}:${String(gridCoordAsNumber(ghostPosition.x))},${String(gridCoordAsNumber(ghostPosition.y))},${ghostPosition.rot}`,
     kind: "ghost",
-    opacity: 0.35,
+    opacity: 0.8,
     pieceId: ghostPosition.id,
     z: Z.ghost,
   } as const;

--- a/src/ui/components/game-board.tsx
+++ b/src/ui/components/game-board.tsx
@@ -408,18 +408,24 @@ export class GameBoard extends SignalWatcher(LitElement) {
     const color = "#111111";
     const borderColor = "#555555";
 
-    // Create subtle gradient for depth
+    // Create subtle gradient for depth with interior margin
+    const margin = 4;
     const gradient = this.ctx.createLinearGradient(
-      pixelX,
-      pixelY,
-      pixelX + this.cellSize,
-      pixelY + this.cellSize,
+      pixelX + margin,
+      pixelY + margin,
+      pixelX + this.cellSize - margin,
+      pixelY + this.cellSize - margin,
     );
     gradient.addColorStop(0, lightenColor(color, 0.1));
     gradient.addColorStop(1, darkenColor(color, 0.9));
 
-    this.ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
-    this.ctx.fillRect(pixelX, pixelY, this.cellSize, this.cellSize);
+    this.ctx.fillStyle = gradient;
+    this.ctx.fillRect(
+      pixelX + margin,
+      pixelY + margin,
+      this.cellSize - margin * 2,
+      this.cellSize - margin * 2,
+    );
 
     // Add subtle highlight on top edge
     this.ctx.fillStyle = lightenColor(color, 0.1);


### PR DESCRIPTION
- Increase ghost overlay opacity from 0.35 to 0.8 for better visibility
- Restore subtle interior gradient with 4px margin for refined structure
- Maintain translucency for target highlight visibility in guided mode
- Fix visibility regression introduced by UI overlay system compound opacity

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>