### PR TITLE
Integrate ghost pieces into UI overlay system

### DIFF
--- a/src/engine/selectors/overlays.ts
+++ b/src/engine/selectors/overlays.ts
@@ -46,9 +46,13 @@ export function selectGhostOverlay(s: GameState): GhostOverlay | null {
   // Ghost only renders during playing state
   if (!isPlaying(s)) return null;
 
-  // Check if ghost is enabled and active piece exists
-  const ghostEnabled = s.gameplay.ghostPieceEnabled ?? true;
-  if (!ghostEnabled || !s.active) return null;
+  // Check if active piece exists
+  if (!s.active) return null;
+
+  // Check ghost enabled state: mode data overrides user settings
+  const modeData = s.modeData as ExtendedModeData | undefined;
+  const ghostEnabled = modeData?.ghostEnabled ?? (s.gameplay.ghostPieceEnabled ?? true);
+  if (!ghostEnabled) return null;
 
   // Calculate ghost position
   const ghostPosition = calculateGhostPosition(s.board, s.active);

--- a/src/engine/selectors/overlays.ts
+++ b/src/engine/selectors/overlays.ts
@@ -1,10 +1,11 @@
 import { calculateGhostPosition } from "../../core/board";
+import { isExtendedModeData } from "../../modes/types";
 import { isPlaying } from "../../state/types";
 import { gridCoordAsNumber } from "../../types/brands";
 import { Z } from "../ui/overlays";
 import { cellsForActivePiece } from "../util/cell-projection";
 
-import type { ExtendedModeData, TargetCell } from "../../modes/types";
+import type { TargetCell } from "../../modes/types";
 import type { GameState, BoardDecoration } from "../../state/types";
 import type { GridCoord } from "../../types/brands";
 import type {
@@ -50,8 +51,9 @@ export function selectGhostOverlay(s: GameState): GhostOverlay | null {
   if (!s.active) return null;
 
   // Check ghost enabled state: mode data overrides user settings
-  const modeData = s.modeData as ExtendedModeData | undefined;
-  const ghostEnabled = modeData?.ghostEnabled ?? (s.gameplay.ghostPieceEnabled ?? true);
+  const modeData = isExtendedModeData(s.modeData) ? s.modeData : undefined;
+  const ghostEnabled =
+    modeData?.ghostEnabled ?? s.gameplay.ghostPieceEnabled ?? true;
   if (!ghostEnabled) return null;
 
   // Calculate ghost position
@@ -151,7 +153,7 @@ export function selectTargetOverlays(
   const targets: Array<TargetOverlay> = [];
 
   // NEW: Read from mode adapter data (ExtendedModeData.targets)
-  const modeData = s.modeData as ExtendedModeData | undefined;
+  const modeData = isExtendedModeData(s.modeData) ? s.modeData : undefined;
   if (modeData?.targets) {
     for (const [i, targetPattern] of modeData.targets.entries()) {
       const overlay = createTargetOverlayFromPattern(targetPattern, i);

--- a/src/modes/guided.ts
+++ b/src/modes/guided.ts
@@ -44,6 +44,17 @@ type GuidedSrsData = Readonly<{
   gradingConfig: GuidedGradingConfig;
 }>;
 
+function isGuidedSrsData(u: unknown): u is GuidedSrsData {
+  if (u === null || typeof u !== "object") return false;
+  const o = u as Record<string, unknown>;
+  return (
+    typeof o["deck"] === "object" &&
+    o["deck"] !== null &&
+    typeof o["gradingConfig"] === "object" &&
+    o["gradingConfig"] !== null
+  );
+}
+
 type RatingFeedback = {
   text: string;
   color: string;
@@ -99,13 +110,13 @@ export class GuidedMode implements GameMode {
   }
 
   getDeck(state: GameState): SrsDeck {
-    const data = state.modeData as GuidedSrsData | undefined;
+    const data = isGuidedSrsData(state.modeData) ? state.modeData : undefined;
     if (data?.deck) return data.deck;
     return makeDefaultDeck(createTimestamp(1));
   }
 
   getGradingConfig(state: GameState): GuidedGradingConfig {
-    const data = state.modeData as GuidedSrsData | undefined;
+    const data = isGuidedSrsData(state.modeData) ? state.modeData : undefined;
     if (data?.gradingConfig) return data.gradingConfig;
     return {
       easyThresholdMs: 1000,

--- a/src/modes/guided.ts
+++ b/src/modes/guided.ts
@@ -76,13 +76,13 @@ const ratingToFeedback = {
 export class GuidedMode implements GameMode {
   readonly name = "guided";
 
-  // Disable hold and ghost piece in guided mode for focused training
+  // Disable hold in guided mode for focused training
+  // Note: Ghost piece control moved to UI adapter system to avoid persisting settings
   initialConfig(): {
-    gameplay: { holdEnabled: boolean; ghostPieceEnabled: boolean };
+    gameplay: { holdEnabled: boolean };
   } {
     return {
       gameplay: {
-        ghostPieceEnabled: false,
         holdEnabled: false,
       },
     };

--- a/src/modes/guided/ui.ts
+++ b/src/modes/guided/ui.ts
@@ -22,12 +22,19 @@ type GuidedSrsData = Readonly<{
   };
 }>;
 
+function isGuidedSrsData(u: unknown): u is GuidedSrsData {
+  if (u === null || typeof u !== "object") return false;
+  const o = u as Record<string, unknown>;
+  // Minimal structural check: presence of deck object is sufficient
+  return typeof o["deck"] === "object" && o["deck"] !== null;
+}
+
 /**
  * Pure function to get the SRS deck from game state.
  * Mirrors the getDeck method from GuidedMode class.
  */
 function getDeck(state: GameState): SrsDeck {
-  const data = state.modeData as GuidedSrsData | undefined;
+  const data = isGuidedSrsData(state.modeData) ? state.modeData : undefined;
   if (data?.deck) return data.deck;
   return makeDefaultDeck(createTimestamp(1));
 }
@@ -130,8 +137,8 @@ export const guidedUi: ModeUiAdapter = {
     // Return target pattern as single array (one target placement)
     // Also suppress ghost pieces in guided mode to avoid visual confusion
     return {
-      targets: [targetCells],
       ghostEnabled: false,
+      targets: [targetCells],
     };
   },
 } as const;

--- a/src/modes/guided/ui.ts
+++ b/src/modes/guided/ui.ts
@@ -128,8 +128,10 @@ export const guidedUi: ModeUiAdapter = {
     }
 
     // Return target pattern as single array (one target placement)
+    // Also suppress ghost pieces in guided mode to avoid visual confusion
     return {
       targets: [targetCells],
+      ghostEnabled: false,
     };
   },
 } as const;

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -22,6 +22,14 @@ export type ExtendedModeData = {
    * Multiple patterns can be displayed simultaneously.
    */
   readonly targets?: ReadonlyArray<ReadonlyArray<TargetCell>>;
+  
+  /**
+   * Whether ghost pieces should be displayed for this mode.
+   * When undefined, defaults to user preference from settings.
+   * When true, forces ghost pieces on regardless of settings.
+   * When false, suppresses ghost pieces for this mode only.
+   */
+  readonly ghostEnabled?: boolean;
 };
 
 /**

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -22,7 +22,7 @@ export type ExtendedModeData = {
    * Multiple patterns can be displayed simultaneously.
    */
   readonly targets?: ReadonlyArray<ReadonlyArray<TargetCell>>;
-  
+
   /**
    * Whether ghost pieces should be displayed for this mode.
    * When undefined, defaults to user preference from settings.
@@ -55,3 +55,31 @@ export type ModeUiAdapter = {
    */
   computeDerivedUi(state: GameState): Partial<ExtendedModeData> | null;
 };
+
+/**
+ * Type guard to safely narrow unknown modeData to ExtendedModeData.
+ * Checks only structural presence of known fields to keep core pure.
+ */
+export function isExtendedModeData(u: unknown): u is ExtendedModeData {
+  if (u === null || typeof u !== "object") return false;
+  const o = u as Record<string, unknown>;
+
+  const ghostOk =
+    o["ghostEnabled"] === undefined || typeof o["ghostEnabled"] === "boolean";
+
+  const targets = o["targets"];
+  const targetsOk =
+    targets === undefined ||
+    (Array.isArray(targets) &&
+      targets.every(
+        (pattern) =>
+          Array.isArray(pattern) &&
+          pattern.every((c) => {
+            if (c === null || typeof c !== "object") return false;
+            const rc = c as Record<string, unknown>;
+            return "x" in rc && "y" in rc && "color" in rc;
+          }),
+      ));
+
+  return ghostOk && targetsOk;
+}

--- a/tests/unit/ghost-overlay-precedence.test.ts
+++ b/tests/unit/ghost-overlay-precedence.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "@jest/globals";
+
+import { selectGhostOverlay } from "../../src/engine/selectors/overlays";
+import { createGridCoord, createDurationMs } from "../../src/types/brands";
+import { createTestGameState } from "../test-helpers";
+
+import type { ActivePiece } from "../../src/state/types";
+
+function makeActivePiece(): ActivePiece {
+  return {
+    id: "T",
+    rot: "spawn",
+    x: createGridCoord(4),
+    y: createGridCoord(-2),
+  };
+}
+
+describe("selectGhostOverlay precedence", () => {
+  it("defaults to enabled when neither modeData nor settings specify", () => {
+    const state = createTestGameState(
+      // No gameplay override; no modeData override
+      {},
+      { active: makeActivePiece() },
+    );
+
+    const overlay = selectGhostOverlay(state);
+    expect(overlay).not.toBeNull();
+    expect(overlay?.kind).toBe("ghost");
+  });
+
+  it("respects user setting when modeData is undefined (disabled)", () => {
+    const state = createTestGameState(
+      {
+        gameplay: {
+          finesseCancelMs: createDurationMs(50),
+          ghostPieceEnabled: false,
+          holdEnabled: true,
+        },
+      },
+      { active: makeActivePiece() },
+    );
+
+    const overlay = selectGhostOverlay(state);
+    expect(overlay).toBeNull();
+  });
+
+  it("modeData.ghostEnabled=true overrides disabled user setting", () => {
+    const state = createTestGameState(
+      {
+        gameplay: {
+          finesseCancelMs: createDurationMs(50),
+          ghostPieceEnabled: false,
+          holdEnabled: true,
+        },
+        modeData: { ghostEnabled: true },
+      },
+      { active: makeActivePiece() },
+    );
+
+    const overlay = selectGhostOverlay(state);
+    expect(overlay).not.toBeNull();
+    expect(overlay?.kind).toBe("ghost");
+  });
+
+  it("modeData.ghostEnabled=false suppresses ghost even if user setting enabled", () => {
+    const state = createTestGameState(
+      {
+        gameplay: {
+          finesseCancelMs: createDurationMs(50),
+          ghostPieceEnabled: true,
+          holdEnabled: true,
+        },
+        modeData: { ghostEnabled: false },
+      },
+      { active: makeActivePiece() },
+    );
+
+    const overlay = selectGhostOverlay(state);
+    expect(overlay).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #issue 19 where guided mode disabled ghost pieces in settings.

## Changes
- Add ghostEnabled flag to ExtendedModeData for mode-specific control
- Update selectGhostOverlay to prioritize mode data over user settings
- Guided mode UI adapter suppresses ghost pieces via overlay system
- Remove problematic ghostPieceEnabled override from guided mode initialConfig
- Preserves user ghost piece preference across mode switches

Generated with [Claude Code](https://claude.ai/code)