### PR TITLE
feat: add guided mode column highlight toggle setting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -715,6 +715,9 @@ export class FinessimoApp {
       gameplay.finesseCancelMs = createDurationMs(newSettings.finesseCancelMs);
     if (newSettings.ghostPieceEnabled !== undefined)
       gameplay.ghostPieceEnabled = newSettings.ghostPieceEnabled;
+    if (newSettings.guidedColumnHighlightEnabled !== undefined)
+      gameplay.guidedColumnHighlightEnabled =
+        newSettings.guidedColumnHighlightEnabled;
     if (newSettings.nextPieceCount !== undefined)
       gameplay.nextPieceCount = newSettings.nextPieceCount;
     if (newSettings.finesseFeedbackEnabled !== undefined)

--- a/src/engine/init.ts
+++ b/src/engine/init.ts
@@ -34,6 +34,7 @@ export const defaultGameplayConfig: GameplayConfig = {
   finesseCancelMs: createDurationMs(50),
   finesseFeedbackEnabled: true,
   ghostPieceEnabled: true,
+  guidedColumnHighlightEnabled: true,
   holdEnabled: true,
   nextPieceCount: 5,
   retryOnFinesseError: false,

--- a/src/engine/selectors/overlays.ts
+++ b/src/engine/selectors/overlays.ts
@@ -183,6 +183,9 @@ export function selectColumnHighlightOverlay(
   // Only active in guided mode
   if (s.currentMode !== "guided") return null;
 
+  // Check if column highlight is enabled
+  if (!(s.gameplay.guidedColumnHighlightEnabled ?? true)) return null;
+
   // Check for active piece
   if (!isPlaying(s) || !s.active) return null;
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -104,6 +104,7 @@ export type GameplayConfig = {
   finesseCancelMs: DurationMs; // default: 50ms
   // Visual/gameplay toggles used by UI renderers
   ghostPieceEnabled?: boolean; // default true
+  guidedColumnHighlightEnabled?: boolean; // default true - show column highlight in guided mode
   nextPieceCount?: number; // default 5 (preview count)
   holdEnabled: boolean; // required - whether hold piece functionality is available
   // Finesse toggles

--- a/src/ui/components/settings-modal.tsx
+++ b/src/ui/components/settings-modal.tsx
@@ -23,6 +23,7 @@ export type GameSettings = {
   gravityMs: number;
   finesseCancelMs: number;
   ghostPieceEnabled: boolean;
+  guidedColumnHighlightEnabled: boolean;
   nextPieceCount: number;
 
   // Finesse settings
@@ -728,6 +729,17 @@ export class SettingsModal extends LitElement {
           <label>
             <input
               type="checkbox"
+              id="guided-column-highlight-enabled"
+              .checked=${this.currentSettings.guidedColumnHighlightEnabled}
+            />
+            Column highlight in Guided mode
+          </label>
+        </div>
+
+        <div class="setting-group">
+          <label>
+            <input
+              type="checkbox"
               id="finesse-boop-enabled"
               .checked=${this.currentSettings.finesseBoopEnabled}
             />
@@ -1018,6 +1030,13 @@ export class SettingsModal extends LitElement {
     if (finesseFeedbackInput)
       newSettings.finesseFeedbackEnabled = finesseFeedbackInput.checked;
 
+    const guidedColumnHighlightInput = this.querySelector<HTMLInputElement>(
+      "#guided-column-highlight-enabled",
+    );
+    if (guidedColumnHighlightInput)
+      newSettings.guidedColumnHighlightEnabled =
+        guidedColumnHighlightInput.checked;
+
     const finesseBoopInput = this.querySelector<HTMLInputElement>(
       "#finesse-boop-enabled",
     );
@@ -1065,6 +1084,7 @@ export class SettingsModal extends LitElement {
       ghostPieceEnabled: true,
       gravityEnabled: true,
       gravityMs: 750,
+      guidedColumnHighlightEnabled: true,
       lineClearDelayMs: 125,
       lockDelayMs: 500,
       mode: "guided",
@@ -1121,6 +1141,8 @@ export class SettingsModal extends LitElement {
     // Gameplay settings
     gravityEnabled: (v: unknown): v is boolean => typeof v === "boolean",
     gravityMs: (v: unknown): v is number => typeof v === "number" && v >= 0,
+    guidedColumnHighlightEnabled: (v: unknown): v is boolean =>
+      typeof v === "boolean",
     // Controls (handled separately in loadStoreFromStorage)
     keyBindings: (_v: unknown): _v is never => false, // Skip - handled separately
     lineClearDelayMs: (v: unknown): v is number =>
@@ -1220,6 +1242,8 @@ export class SettingsModal extends LitElement {
       ghostPieceEnabled: gameState.gameplay.ghostPieceEnabled ?? true,
       gravityEnabled: gameState.timing.gravityEnabled,
       gravityMs: gameState.timing.gravityMs,
+      guidedColumnHighlightEnabled:
+        gameState.gameplay.guidedColumnHighlightEnabled ?? true,
       lineClearDelayMs: gameState.timing.lineClearDelayMs,
       lockDelayMs: gameState.timing.lockDelayMs,
       mode: maybeMode,

--- a/tests/types/settings-schema.test.ts
+++ b/tests/types/settings-schema.test.ts
@@ -18,6 +18,7 @@ type SchemaKeys = keyof {
   gravityMs: unknown;
   finesseCancelMs: unknown;
   ghostPieceEnabled: unknown;
+  guidedColumnHighlightEnabled: unknown;
   nextPieceCount: unknown;
   finesseFeedbackEnabled: unknown;
   finesseBoopEnabled: unknown;

--- a/tests/unit/overlays.test.ts
+++ b/tests/unit/overlays.test.ts
@@ -189,6 +189,24 @@ describe("overlays.ts", () => {
         expect(overlay.columns.length).toBeGreaterThan(0);
       }
     });
+
+    it("should return null when column highlight is disabled", () => {
+      const guidedStateWithDisabledHighlight: GameState = createTestGameState(
+        {
+          currentMode: "guided",
+          gameplay: {
+            ...basePlayingState.gameplay,
+            guidedColumnHighlightEnabled: false,
+          },
+        },
+        { active: mockActivePiece },
+      );
+
+      const overlay = selectColumnHighlightOverlay(
+        guidedStateWithDisabledHighlight,
+      );
+      expect(overlay).toBeNull();
+    });
   });
 
   describe("selectDerivedOverlays", () => {


### PR DESCRIPTION
Add new setting to enable/disable column highlighting in guided mode, following the same pattern as the ghost piece setting.

Changes:
- Add guidedColumnHighlightEnabled field to GameplayConfig (default: true)
- Add checkbox in Finesse tab of settings modal: "Column highlight in Guided mode"
- Update settings collection, storage, validation, and state mapping
- Modify selectColumnHighlightOverlay to check the setting before rendering
- Add test coverage for disabled column highlight functionality
- Update type tests to include new setting field

The setting is persisted to localStorage and only affects guided mode column highlighting behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
